### PR TITLE
docs: add example snippet for adding custom schema for yamlls

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ require('lspconfig').jsonls.setup {
 If you want to use your own schemas in addition to schemas from SchemaStore, you can merge them:
 
 ```lua
+-- JSON LSP
 require('lspconfig').jsonls.setup {
   settings = {
     json = {
@@ -125,6 +126,18 @@ require('lspconfig').jsonls.setup {
       validate = { enable = true },
     },
   },
+}
+
+-- YAML LSP
+require('lspconfig').yamlls.setup {
+  settings = {
+    yaml = {
+      validate = true,
+      schemas = vim.tbl_extend("keep", {
+        ["https://example.com/schema/foobar.json"] = { 'foobar.json', '.foobar.json' }
+      }, require('schemastore').yaml.schemas())
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
I struggled for a while to get the YAML language server to pick up my
custom schema as I was providing the same structure as to the JSON
language server. However, as the YAML language server expects a
`{ url = fileMatch }` this was not working. I figured it'd be helpful
for others to include this in the README.

I also believe #9 can be closed now because there's already a
`require('schemastore').yaml.schemas()` function!
