### PR TITLE
fix: default file match for sam tempaltes

### DIFF
--- a/lua/schemastore/catalog.lua
+++ b/lua/schemastore/catalog.lua
@@ -1508,7 +1508,7 @@ M.json = {
       url = "https://raw.githubusercontent.com/awslabs/goformation/master/schema/cloudformation.schema.json"
     }, {
       description = "The AWS Serverless Application Model (AWS SAM, previously known as Project Flourish) extends AWS CloudFormation to provide a simplified way of defining the Amazon API Gateway APIs, AWS Lambda functions, and Amazon DynamoDB tables needed by your serverless application.",
-      fileMatch = { "serverless.template", "*.sam.json", "*.sam.yml", "*.sam.yaml", "sam.json", "sam.yml", "sam.yaml" },
+      fileMatch = { "serverless.template", "*.sam.json", "*.sam.yml", "*.sam.yaml", "sam.json", "sam.yml", "sam.yaml", "template.yaml" },
       name = "AWS CloudFormation Serverless Application Model (SAM)",
       url = "https://raw.githubusercontent.com/aws/serverless-application-model/main/samtranslator/schema/schema.json"
     }, {


### PR DESCRIPTION
The default file name for SAM templates is `template.yaml` but it's missing in the default config. This PR aims to add it.
