### PR TITLE
mention disabling built-in for yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ For an explanation of why the `validate = { enable = true }` option is recommend
 require('lspconfig').yamlls.setup {
   settings = {
     yaml = {
+      schemaStore = {
+        -- You must disable built-in schemaStore support if you want to use
+        -- this plugin and its advanced options like `ignore`.
+        enable = false,
+      },
       schemas = require('schemastore').yaml.schemas(),
     },
   },


### PR DESCRIPTION
You must disable built-in schemaStore support if you want to use this plugin and its advanced options like `ignore`.

- to validate this, create a `conf.yml` file
- it will be registered as a Cheatsheets schema
- disable Cheatsheets using `ignore` option

observed:
- the conf.yml is still being validated against the Cheatsheets schema

expected:
- conf.yml should have no schema validation

to fix, disable built-in and the observed result is as expected.