### PR TITLE
Document yaml option to fix LSP completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ require('lspconfig').yamlls.setup {
         -- You must disable built-in schemaStore support if you want to use
         -- this plugin and its advanced options like `ignore`.
         enable = false,
+        -- Avoid TypeError: Cannot read properties of undefined (reading 'length')
+        url = "",
       },
       schemas = require('schemastore').yaml.schemas(),
     },


### PR DESCRIPTION
In YAML files LSP completion is not happening because `yaml-language-server` is failing with error:

    TypeError: Cannot read properties of undefined (reading 'length')

from `out/server/src/languageserver/handlers/settingsHandlers.js:78:51`, which it's expecting to have `yaml.schemaStore.url.length` and it doesn't exist.

Signed-off-by: Javier Tia <javier.tia@gmail.com>
