### PR TITLE
Update SchemaStore catalog

### DIFF
--- a/lua/schemastore/catalog.lua
+++ b/lua/schemastore/catalog.lua
@@ -2872,7 +2872,7 @@ M.json = {
       url = "https://json.schemastore.org/lsdlschema.json"
     }, {
       description = "A micro editor config",
-      fileMatch = { "*.settings.json" },
+      fileMatch = { "settings.json" },
       name = "A micro editor config",
       url = "https://json.schemastore.org/micro.json"
     }, {


### PR DESCRIPTION
I was facing issues with tsconfig.settings.json files receiving micro editor config schema.

```nvim
▌  tsconfig.settings…
   12 {
W  11   "compilerOptions": {
        └──── Property compilerOptions is not allowed.
┃  10     "target": "es2022",
    9     "module": "commonjs",
    8     "declaration": true,
    7     "declarationMap": true,

```

At first, I thought to ignore like this:

```lua
ignore = {
    -- I don't use Micro editor config files
    -- The matcher is *.settings.json, which overrides things like tsconfig.setttings.json
    -- I am not sure what the right solution is
    'A micro editor config',
},
```

Here are the respective configurations:

https://github.com/b0o/SchemaStore.nvim/blob/a78822176d936d6b3e12fff25df69a9c49a84ba0/lua/schemastore/catalog.lua#L2874-L2878

https://github.com/b0o/SchemaStore.nvim/blob/a78822176d936d6b3e12fff25df69a9c49a84ba0/lua/schemastore/catalog.lua#L4044-L4048

I looked into why Micro editor is so greedy with it's schema matching. Does micro really use `*.settings.json` files for config? I think not, here is what my search finds:
https://github.com/search?q=repo%3Azyedidia%2Fmicro%20settings.json&type=code

As you can see, the Micro editor only reserves `settings.json`.

However, I feel like there is greater issue at play. I am not sure the right solution, but I think that more specific matchers should override less specific ones. I tried to fix this problem this way:

```lua
replace = {
    ['tsconfig.json'] = {
        description = "TypeScript compiler configuration file",
        fileMatch = { "tsconfig*.json", "tsconfig.*.json" },
        name = "tsconfig.json",
        url = "https://json.schemastore.org/tsconfig.json"
    },
},
```

But that still did not work. I also feel like the default config should already work.

Regardless, Micro config files only need `settings.json` reserved.
