### PR TITLE
fix: chrome ext add missing file match

### DIFF
--- a/lua/schemastore/catalog.lua
+++ b/lua/schemastore/catalog.lua
@@ -1910,6 +1910,7 @@ M.json = {
     }, {
       description = "Google Chrome extension manifest file",
       name = "Chrome Extension",
+      fileMatch = { "manifest.json" },
       url = "https://json.schemastore.org/chrome-manifest.json"
     }, {
       description = "Google Chrome extension localization file",
@@ -4630,16 +4631,6 @@ M.json = {
       fileMatch = { "studio.config.json" },
       name = "<div>RIOTS' studio configuration",
       url = "https://webcomponents.dev/assets2/schemas/studio.config.json"
-    }, {
-      description = "WebExtension manifest files",
-      fileMatch = { "manifest.json" },
-      name = "WebExtensions",
-      url = "https://json.schemastore.org/webextension.json"
-    }, {
-      description = "Web Application manifest file",
-      fileMatch = { "manifest.json", "*.webmanifest" },
-      name = "Web App Manifest",
-      url = "https://json.schemastore.org/web-manifest-combined.json"
     }, {
       description = "Azure Webjob list file",
       fileMatch = { "webjobs-list.json" },


### PR DESCRIPTION
Hey, I am having manifest.json for chrome extension and it's complaining about wrong schema, it's expecting old deprecated v2 manifest. I am using newest version of SchemaStore and what I've found is that there's a missing `fileMatch` field, I am not sure if this is correct way of fixing this.